### PR TITLE
Allow a configurable default queue value on push and index requests

### DIFF
--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/IndexingServiceImpl.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/IndexingServiceImpl.java
@@ -997,7 +997,7 @@ public class IndexingServiceImpl extends BaseApiService<CloudSearch> implements 
   }
 
   private String getQueue(String queue) {
-    return queue == null ? this.defaultQueue : queue;
+    return (queue == null || queue.isEmpty()) ? this.defaultQueue : queue;
   }
 
   /**


### PR DESCRIPTION
api.defaultQueue will set a default queue value on push and index requests if they don't already have a value for queue.