### PR TITLE
Escape + and ; in resource names.

### DIFF
--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/IndexingServiceImpl.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/IndexingServiceImpl.java
@@ -59,9 +59,7 @@ import com.google.api.services.cloudsearch.v1.model.UploadItemRef;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.escape.Escaper;
 import com.google.common.io.ByteStreams;
-import com.google.common.net.UrlEscapers;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -81,8 +79,6 @@ import com.google.enterprise.cloudsearch.sdk.StatsManager.OperationStats;
 import com.google.enterprise.cloudsearch.sdk.config.Configuration;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -148,7 +144,6 @@ public class IndexingServiceImpl extends BaseApiService<CloudSearch> implements 
   public static final int DEFAULT_CONTENT_UPLOAD_THRESHOLD_BYTES = 100000; // ~100KB
   public static final Set<String> API_SCOPES =
       Collections.singleton("https://www.googleapis.com/auth/cloud_search");
-  private static final Escaper URL_PATH_SEGMENT_ESCAPER = UrlEscapers.urlPathSegmentEscaper();
   private static final RequestMode DEFAULT_REQUEST_MODE = RequestMode.SYNCHRONOUS;
 
   private final String sourceId;
@@ -1062,18 +1057,6 @@ public class IndexingServiceImpl extends BaseApiService<CloudSearch> implements 
       return name;
     }
     return String.format(ITEM_RESOURCE_NAME_FORMAT, sourceId, escapeResourceName(name));
-  }
-
-  private static String escapeResourceName(String name) {
-    return URL_PATH_SEGMENT_ESCAPER.escape(name);
-  }
-
-  private static String decodeResourceName(String name) {
-    try {
-      return URLDecoder.decode(name.replace("+", "%2B"), "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalArgumentException("unable to decode resource name " + name, e);
-    }
   }
 
   private void removeResourcePrefix(Item item) {

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IndexingServiceTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IndexingServiceTest.java
@@ -1037,7 +1037,7 @@ public class IndexingServiceTest {
 
     verify(quotaServer).acquire(Operations.DEFAULT);
     verify(batchingService).pushItem(pushCaptor.capture());
-    assertThat(pushCaptor.getValue().getName(), endsWith("/a+b%2Fc"));
+    assertThat(pushCaptor.getValue().getName(), endsWith("/a%2Bb%2Fc"));
   }
 
   @Test

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/template/RepositoryDocTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/template/RepositoryDocTest.java
@@ -261,7 +261,7 @@ public class RepositoryDocTest {
             .setItem(item)
             .setContent(content, ContentFormat.TEXT)
             .addChildId("id1", pushItem1)
-            .addChildId("id2", pushItem2)
+            .addChildId("id2+b;more", pushItem2)
             .build();
 
     SettableFuture<Item> updateFuture = SettableFuture.create();
@@ -286,7 +286,7 @@ public class RepositoryDocTest {
     verify(mockIndexingService)
         .indexItemAndContent(item, content, null, ContentFormat.TEXT, RequestMode.UNSPECIFIED);
     verify(mockIndexingService).push("id1", pushItem1);
-    verify(mockIndexingService).push("id2", pushItem2);
+    verify(mockIndexingService).push("id2+b;more", pushItem2);
   }
 
   @Test

--- a/it/src/main/java/com/google/enterprise/cloudsearch/sdk/Util.java
+++ b/it/src/main/java/com/google/enterprise/cloudsearch/sdk/Util.java
@@ -35,7 +35,10 @@ public class Util {
   }
 
   public static String getItemId(String sourceId, String name) {
-    return "datasources/" + sourceId + "/items/" + name;
+    return "datasources/" + sourceId + "/items/" + BaseApiService.escapeResourceName(name);
   }
 
+  public static String unescapeItemName(String name) {
+    return BaseApiService.decodeResourceName(name);
+  }
 }

--- a/it/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/MockItem.java
+++ b/it/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/MockItem.java
@@ -61,7 +61,7 @@ public class MockItem {
   }
 
   public Item getItem() {
-    Item item = new IndexingItemBuilder(name)
+    return new IndexingItemBuilder(name)
         .setValues(values)
         .setTitle(FieldOrValue.withField(TITLE))
         .setSourceRepositoryUrl(FieldOrValue.withField(URL))
@@ -78,7 +78,6 @@ public class MockItem {
         .setPayload(getByteArrayValue(values, PAYLOAD))
         .setAcl(MockItem.<Acl>getSingleValue(values, ACL).orElse(null))
         .build();
-    return item;
   }
 
   private static ItemType getItemType(Multimap<String, Object> values) {


### PR DESCRIPTION
Also, escape resource names for the integration tests.

Bug: 110212500
Bug: 130297436
Bug: 133445325
Bug: 133830687
Change-Id: I045b1987537c6f2ced15ad48f0f40d1c320af326