### PR TITLE
Add helper to support include/exclude configuration

### DIFF
--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilter.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilter.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.enterprise.cloudsearch.sdk.indexing;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.enterprise.cloudsearch.sdk.InvalidConfigurationException;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import javax.annotation.Nullable;
+
+/**
+ * Helper utility to check if a particular item should be indexed. Include/exclude
+ * patterns are specified using Java regular expressions; see <a
+ * href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">java.util.regex.Pattern</a>. Include/exclude
+ * patterns are specified in a separate configuration file.
+ *
+ * <p>Configuration file:
+ * <li>the path to the include/exclude pattern file is defined by the configuration property
+ *     <b>connector.includeExcludeFilter.includeExcludePatternFile</b>
+ * <li>include patterns are prefixed with "include:regex:"
+ * <li>exclude patterns are prefixed with "exclude:regex:"
+ */
+public class IncludeExcludeFilter {
+  private static final Logger logger = Logger.getLogger(IncludeExcludeFilter.class.getName());
+  private static final String INCLUDE_RULE_PREFIX = "include:regex:";
+  private static final String EXCLUDE_RULE_PREFIX = "exclude:regex:";
+
+  @VisibleForTesting final List<Rule<String>> includeRules;
+  @VisibleForTesting final List<Rule<String>> excludeRules;
+
+  public IncludeExcludeFilter(List<Rule<String>> includeRules, List<Rule<String>> excludeRules) {
+    this.includeRules = includeRules;
+    this.excludeRules = excludeRules;
+  }
+
+  public static IncludeExcludeFilter fromConfiguration() {
+    checkState(Configuration.isInitialized());
+    String includeExcludePatternFile =
+        Configuration.getString("connector.includeExcludeFilter.includeExcludePatternFile", "").get();
+    if (Strings.isNullOrEmpty(includeExcludePatternFile)) {
+      return new IncludeExcludeFilter(ImmutableList.of(), ImmutableList.of());
+    }
+    try {
+      return fromFile(includeExcludePatternFile);
+    } catch (IOException e) {
+      throw new InvalidConfigurationException(
+          "Error loading IncludeExcludeFilter configuration.", e);
+    }
+  }
+
+  public static IncludeExcludeFilter fromFile(String filePath)
+      throws FileNotFoundException, IOException {
+    File configFile = new File(filePath);
+    if (!configFile.exists()) {
+      throw new InvalidConfigurationException(String.format("Path [%s] does not exist", filePath));
+    }
+    if (configFile.isDirectory()) {
+      throw new InvalidConfigurationException(
+          String.format("Path [%s] points to directory instead of file", filePath));
+    }
+    List<Rule<String>> includeRules = new ArrayList<IncludeExcludeFilter.Rule<String>>();
+    List<Rule<String>> excludeRules = new ArrayList<IncludeExcludeFilter.Rule<String>>();
+    try (BufferedReader br = new BufferedReader(new FileReader(configFile))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        try {
+          if (line.startsWith(INCLUDE_RULE_PREFIX)) {
+            includeRules.add(
+                new Rule<>(new RegexPredicate(line.substring(INCLUDE_RULE_PREFIX.length()))));
+          } else if (line.startsWith(EXCLUDE_RULE_PREFIX)) {
+            excludeRules.add(
+                new Rule<>(new RegexPredicate(line.substring(EXCLUDE_RULE_PREFIX.length()))));
+          } else {
+            logger.log(Level.WARNING, "Invalid Rule [{0}] for include exclude pattern", line);
+          }
+
+        } catch (PatternSyntaxException e) {
+          throw new InvalidConfigurationException("Invalid regex pattern " + line, e);
+        }
+      }
+    }
+    return new IncludeExcludeFilter(includeRules, excludeRules);
+  }
+
+  public boolean isAllowed(String value) {
+    boolean exclude = evaluateRules(excludeRules, value, false /* nothing is excluded */);
+    if (exclude) {
+      logger.log(Level.FINEST, "excluding " + value);
+      return false;
+    }
+    return evaluateRules(includeRules, value, true /* everything is included */);
+  }
+
+  private boolean evaluateRules(List<Rule<String>> rules, String value, boolean emptyRulesOutcome) {
+    if (rules.isEmpty()) {
+      return emptyRulesOutcome;
+    }
+    return rules.stream().map(r -> r.eval(value)).filter(e -> e == true).findFirst().orElse(false);
+  }
+
+  private static class Rule<T> {
+    private final Predicate<T> predicate;
+
+    public Rule(Predicate<T> predicate) {
+      this.predicate = checkNotNull(predicate);
+    }
+
+    public boolean eval(T val) {
+      return predicate.apply(val);
+    }
+  }
+
+  private static class RegexPredicate implements Predicate<String> {
+    private final Pattern p;
+    private final String regex;
+
+    private RegexPredicate(String regex) {
+      this.p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+      this.regex = regex;
+    }
+
+    @Override
+    public boolean apply(@Nullable String input) {
+      Matcher matcher = p.matcher(input);
+      boolean matches = matcher.matches();
+      logger.log(
+          Level.FINE,
+          "Pattern [{0}] input [{1}] matches Outcome [{2}] with Regex[{3}]",
+          new Object[] {p, input, matches, regex});
+      return matches;
+    }
+  }
+}

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilterTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilterTest.java
@@ -24,6 +24,13 @@ import com.google.enterprise.cloudsearch.sdk.InvalidConfigurationException;
 import com.google.enterprise.cloudsearch.sdk.config.Configuration.ResetConfigRule;
 import com.google.enterprise.cloudsearch.sdk.config.Configuration.SetupConfigRule;
 import com.google.enterprise.cloudsearch.sdk.indexing.IndexingItemBuilder.ItemType;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.regex.PatternSyntaxException;
 import org.junit.Rule;
@@ -52,7 +59,7 @@ public class IncludeExcludeFilterTest {
         .setAction("INCLUDE")
         .build();
     assertEquals("testRule", rule.getName());
-    assertEquals(ItemType.CONTENT_ITEM, rule.getItemType());
+    assertEquals(ItemType.CONTENT_ITEM, rule.getItemType().get());
     assertEquals(IncludeExcludeFilter.Action.INCLUDE, rule.getAction());
   }
 
@@ -65,10 +72,35 @@ public class IncludeExcludeFilterTest {
   }
 
   @Test
-  public void ruleBuilder_missingItemType_throwsException() {
+  public void ruleBuilder_regexMissingItemType_throwsException() {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Rule item type");
     IncludeExcludeFilter.Rule rule = new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setFilterType("REGEX")
+        .setFilterPattern("file.txt")
+        .setAction("INCLUDE")
+        .build();
+  }
+
+  @Test
+  public void ruleBuilder_prefixMissingItemType_isEmpty() {
+    IncludeExcludeFilter.Rule rule = new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setFilterType("FILE_PREFIX")
+        .setFilterPattern("/file")
+        .setAction("INCLUDE")
+        .build();
+    assertTrue(!rule.getItemType().isPresent());
+  }
+
+  @Test
+  public void ruleBuilder_prefixHasItemType_throwsException() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Item type should not be set");
+    IncludeExcludeFilter.Rule rule = new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setItemType("CONTENT_ITEM")
+        .setFilterType("FILE_PREFIX")
+        .setFilterPattern("/file")
+        .setAction("INCLUDE")
         .build();
   }
 
@@ -147,6 +179,262 @@ public class IncludeExcludeFilterTest {
   }
 
   @Test
+  public void regexRule_configInvalidPattern_throwsException() {
+    thrown.expect(PatternSyntaxException.class);
+    IncludeExcludeFilter.Rule rule = new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setItemType("CONTENT_ITEM")
+        .setFilterType("REGEX")
+        .setAction("INCLUDE")
+        .setFilterPattern("*")
+        .build();
+  }
+
+  @Test
+  public void regexRule_nullInput_returnsFalse() {
+    IncludeExcludeFilter.Rule rule = new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setItemType("CONTENT_ITEM")
+        .setFilterType("REGEX")
+        .setAction("INCLUDE")
+        .setFilterPattern("any")
+        .build();
+    assertFalse(rule.eval(null));
+  }
+
+  @Test
+  public void filePrefixRule_configInvalidPath_throwsException() {
+    thrown.expect(IllegalArgumentException.class);
+    IncludeExcludeFilter.Rule rule = new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setFilterType("FILE_PREFIX")
+        .setAction("INCLUDE")
+        .setFilterPattern("not-an-absolute-path")
+        .build();
+  }
+
+  @Test
+  public void filePrefixRule_nullPath_returnsFalse() {
+    IncludeExcludeFilter.Rule rule = new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setFilterType("FILE_PREFIX")
+        .setFilterPattern("/path/to/content")
+        .setAction("INCLUDE")
+        .build();
+    assertFalse(rule.eval(null));
+  }
+
+  @Test
+  public void filePrefixIncludeRule_acceptsExpectedPatterns() {
+    List<IncludeExcludeFilter.Rule> rules;
+
+    rules = Arrays.asList(
+        filePrefixRule("/", "INCLUDE"));
+    eval(true, rules,
+        "/",
+        "/folder",
+        "/folder/",
+        "/folder/path",
+        "/folder/path/",
+        "/folder/path/file.txt",
+        "/folder/path/nestedfolder/file.txt");
+
+    rules = Arrays.asList(
+        filePrefixRule("/folder", "INCLUDE"),
+        filePrefixRule("/folder/", "INCLUDE"));
+    eval(true, rules,
+        "/",
+        "/folder",
+        "/folder/",
+        "/folder/path",
+        "/folder/path/",
+        "/folder/path/file.txt",
+        "/folder/path/nestedfolder/file.txt");
+    eval(false, rules,
+        "/folderWithLongerName",
+        "/otherFolder",
+        "/folder.txt");
+
+    rules = Arrays.asList(
+        filePrefixRule("/folder/path", "INCLUDE"),
+        filePrefixRule("/folder/path/", "INCLUDE"));
+    eval(true, rules,
+        "/",
+        "/folder",
+        "/folder/",
+        "/folder/path",
+        "/folder/path/",
+        "/folder/path/file.txt",
+        "/folder/path/nestedfolder/file.txt");
+    eval(false, rules,
+        "/folderWithLongerName",
+        "/folder/otherSubfolder",
+        "/folder/pathWithLongerName",
+        "/folder/file.txt",
+        "/folder/subfolder/file.txt");
+  }
+
+  @Test
+  public void filePrefixExcludeRule_acceptsExpectedPatterns() {
+    List<IncludeExcludeFilter.Rule> rules;
+
+    rules = Arrays.asList(
+        filePrefixRule("/folder", "EXCLUDE"));
+    eval(true, rules,
+        "/folder",
+        "/folder/",
+        "/folder/path",
+        "/folder/path/",
+        "/folder/path/file.txt",
+        "/folder/path/nestedfolder/file.txt");
+    eval(false, rules,
+        "/",
+        "/folderWithLongerName/",
+        "/otherFolder/path/nestedfolder/file.txt");
+  }
+
+  @Test
+  public void urlPrefixRule_configInvalidUrl_throwsException() {
+    thrown.expect(IllegalArgumentException.class);
+    urlPrefixRule("not-an-url", "INCLUDE");
+  }
+
+  @Test
+  public void urlPrefixRule_nullUrl_returnsFalse() {
+    IncludeExcludeFilter.Rule rule = urlPrefixRule("http://www.example.com", "INCLUDE");
+    assertFalse(rule.eval(null));
+  }
+
+  @Test
+  public void urlPrefixRule_invalidUrl_returnsFalse() {
+    IncludeExcludeFilter.Rule rule = urlPrefixRule("http://www.example.com", "INCLUDE");
+    assertFalse(rule.eval("not-an-url"));
+  }
+
+  @Test
+  public void urlPrefixRule_acceptsExpectedPatterns() {
+    List<IncludeExcludeFilter.Rule> rules;
+
+    rules = Arrays.asList(
+        urlPrefixRule("http://www.example.com", "INCLUDE"),
+        urlPrefixRule("http://www.example.com/", "INCLUDE"));
+    eval(true, rules,
+        "http://www.example.com",
+        "http://www.example.com/",
+        "http://WWW.EXAMPLE.COM",
+        "http://WWW.EXAMPLE.COM/",
+        "http://www.example.com/anyPath");
+    eval(false, rules,
+        "http://www.example.com:80",
+        "http://docs.example.com",
+        "http://docs.example.com/",
+        "https://www.example.com",
+        "http://other.example.com");
+
+    rules = Arrays.asList(
+        urlPrefixRule("http://www.example.com:1234", "INCLUDE"),
+        urlPrefixRule("http://www.example.com:1234/", "INCLUDE"));
+    eval(true, rules,
+        "http://www.example.com:1234",
+        "http://www.example.com:1234/",
+        "http://WWW.EXAMPLE.COM:1234",
+        "http://WWW.EXAMPLE.COM:1234/",
+        "http://www.example.com:1234/?x=y",
+        "http://www.example.com:1234/anyPath");
+    eval(false, rules,
+        "http://www.example.com:123",
+        "http://www.example.com:12345",
+        "http://www.example.com:12345/",
+        "https://www.example.com:1234",
+        "http://other.example.com:1234");
+
+    rules = Arrays.asList(
+        urlPrefixRule("http://www.example.com/folder", "INCLUDE"),
+        urlPrefixRule("http://www.example.com/folder/", "INCLUDE"));
+    eval(true, rules,
+        "http://www.example.com",
+        "http://www.example.com/",
+        "http://www.example.com/folder",
+        "http://www.example.com/folder/",
+        "http://www.example.com/folder/file.txt",
+        "http://www.example.com/folder/path/to/file.txt",
+        "http://www.example.com/folder?x=11",
+        "http://www.example.com/folder/path?x=11",
+        "http://www.example.com/folder;x=11",
+        "http://www.example.com/folder#id");
+    eval(false, rules,
+        "http://docs.example.com/",
+        "http://www.example.com/otherfolder",
+        "http://www.example.com/folderWithLongerName",
+        "http://www.example.com/file.txt");
+  }
+
+  @Test
+  public void urlPrefixExcludeRule_acceptsExpectedPatterns() {
+    List<IncludeExcludeFilter.Rule> rules;
+
+    rules = Arrays.asList(
+        urlPrefixRule("http://www.example.com/folder", "EXCLUDE"),
+        urlPrefixRule("http://www.example.com/folder/", "EXCLUDE"));
+    eval(true, rules,
+        "http://www.example.com/folder",
+        "http://www.example.com/folder/",
+        "http://www.example.com/folder/file.txt");
+    eval(false, rules,
+        "http://www.example.com",
+        "http://www.example.com/",
+        "http://www.example.com/folderWithLongerName",
+        "http://www.example.com/otherFolder");
+  }
+
+  private IncludeExcludeFilter.Rule filePrefixRule(String prefix, String action) {
+    return new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setFilterType("FILE_PREFIX")
+        .setAction(action)
+        .setFilterPattern(prefix)
+        .build();
+  }
+
+  private IncludeExcludeFilter.Rule urlPrefixRule(String prefix, String action) {
+    return new IncludeExcludeFilter.Rule.Builder("testRule")
+        .setFilterType("URL_PREFIX")
+        .setAction(action)
+        .setFilterPattern(prefix)
+        .build();
+
+  }
+
+  private void eval(boolean expected, List<IncludeExcludeFilter.Rule> rules, String... values) {
+    for (IncludeExcludeFilter.Rule rule : rules) {
+      for (String s : values) {
+        assertEquals(rule + " = " + s, expected, rule.eval(s));
+      }
+    }
+  }
+
+  @Test
+  public void constructor_sortsRules() {
+    List<IncludeExcludeFilter.Rule> rules = Arrays.asList(
+        new IncludeExcludeFilter.Rule.Builder("rule1").setFilterType("URL_PREFIX")
+        .setAction("INCLUDE").setFilterPattern("http://example.com/a").build(),
+        new IncludeExcludeFilter.Rule.Builder("rule2").setFilterType("URL_PREFIX")
+        .setAction("INCLUDE").setFilterPattern("http://example.com/b").build(),
+        new IncludeExcludeFilter.Rule.Builder("rule3").setFilterType("URL_PREFIX")
+        .setAction("EXCLUDE").setFilterPattern("http://private.example.com/").build(),
+        new IncludeExcludeFilter.Rule.Builder("rule4").setFilterType("REGEX")
+        .setAction("INCLUDE").setFilterPattern("\\.html$").setItemType("CONTENT_ITEM").build(),
+        new IncludeExcludeFilter.Rule.Builder("rule5").setFilterType("REGEX")
+        .setAction("INCLUDE").setFilterPattern("\\.pdf$").setItemType("CONTENT_ITEM").build(),
+        new IncludeExcludeFilter.Rule.Builder("rule6").setFilterType("REGEX")
+        .setAction("EXCLUDE").setFilterPattern("\\.pdf.bak$").setItemType("CONTENT_ITEM").build(),
+        new IncludeExcludeFilter.Rule.Builder("rule6").setFilterType("REGEX")
+        .setAction("EXCLUDE").setFilterPattern("\\.doc.bak$").setItemType("CONTENT_ITEM").build(),
+        new IncludeExcludeFilter.Rule.Builder("rule6").setFilterType("REGEX")
+        .setAction("EXCLUDE").setFilterPattern("\\.txt.bak$").setItemType("CONTENT_ITEM").build());
+    IncludeExcludeFilter filter = new IncludeExcludeFilter(rules);
+    assertEquals(2, filter.prefixIncludeRules.size());
+    assertEquals(1, filter.prefixExcludeRules.size());
+    assertEquals(2, filter.regexIncludeRules.get(ItemType.CONTENT_ITEM).size());
+    assertEquals(3, filter.regexExcludeRules.get(ItemType.CONTENT_ITEM).size());
+  }
+
+  @Test
   public void fromConfiguration_notInitialized_throwsException() {
     thrown.expect(IllegalStateException.class);
     IncludeExcludeFilter.fromConfiguration();
@@ -156,11 +444,13 @@ public class IncludeExcludeFilterTest {
   public void fromConfiguration_initializedNoConfig_emptyRulesCreated() {
     setupConfig.initConfig(new Properties());
     IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
-    assertEquals(ItemType.values().length, filter.includeRules.size());
-    assertEquals(ItemType.values().length, filter.excludeRules.size());
+    assertEquals(0, filter.prefixIncludeRules.size());
+    assertEquals(0, filter.prefixExcludeRules.size());
+    assertEquals(ItemType.values().length, filter.regexIncludeRules.size());
+    assertEquals(ItemType.values().length, filter.regexExcludeRules.size());
     for (ItemType itemType : ItemType.values()) {
-      assertEquals(0, filter.includeRules.get(itemType).size());
-      assertEquals(0, filter.excludeRules.get(itemType).size());
+      assertEquals(0, filter.regexIncludeRules.get(itemType).size());
+      assertEquals(0, filter.regexExcludeRules.get(itemType).size());
     }
     assertTrue(filter.isAllowed("anything is allowed", ItemType.CONTENT_ITEM));
     assertTrue(filter.isAllowed("anything is allowed", ItemType.CONTAINER_ITEM));
@@ -189,21 +479,97 @@ public class IncludeExcludeFilterTest {
   }
 
   @Test
-  public void fromConfiguration_includeRule_succeeds() {
-    Properties config = new Properties();
-    config.setProperty("includeExcludeFilter.includeText.itemType", "CONTENT_ITEM");
-    config.setProperty("includeExcludeFilter.includeText.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.includeText.filterPattern", "\\.txt$");
-    config.setProperty("includeExcludeFilter.includeText.action", "INCLUDE");
+  public void fromConfiguration_regexRules_rulesCreated() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.includeText.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.includeText.filterType = REGEX",
+        "includeExcludeFilter.includeText.filterPattern = \\\\.txt$",
+        "includeExcludeFilter.includeText.action = INCLUDE",
+
+        "includeExcludeFilter.includeHtml.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.includeHtml.filterType = REGEX",
+        "includeExcludeFilter.includeHtml.filterPattern = \\\\.html$",
+        "includeExcludeFilter.includeHtml.action = INCLUDE",
+
+        "includeExcludeFilter.excludeHtml.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.excludeHtml.filterType = REGEX",
+        "includeExcludeFilter.excludeHtml.filterPattern = excluded\\\\.html$",
+        "includeExcludeFilter.excludeHtml.action = EXCLUDE"
+      );
     setupConfig.initConfig(config);
     IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
-    assertEquals(1, filter.includeRules.get(ItemType.CONTENT_ITEM).size());
-    assertEquals(0, filter.excludeRules.get(ItemType.CONTENT_ITEM).size());
-    IncludeExcludeFilter.Rule rule = filter.includeRules.get(ItemType.CONTENT_ITEM).get(0);
-    assertEquals("includeText", rule.getName());
-    assertEquals(ItemType.CONTENT_ITEM, rule.getItemType());
-    assertEquals(IncludeExcludeFilter.Action.INCLUDE, rule.getAction());
 
+    List<IncludeExcludeFilter.Rule> includeRules =
+        filter.regexIncludeRules.get(ItemType.CONTENT_ITEM);
+    assertEquals(2, includeRules.size());
+
+    IncludeExcludeFilter.Rule rule = includeRules.stream()
+        .filter(r -> r.getName().equals("includeText"))
+        .findFirst()
+        .get();
+    assertEquals(ItemType.CONTENT_ITEM, rule.getItemType().get());
+    assertEquals(IncludeExcludeFilter.Action.INCLUDE, rule.getAction());
+    assertEquals("\\.txt$", rule.getPredicate().toString());
+
+    rule = includeRules.stream()
+        .filter(r -> r.getName().equals("includeHtml"))
+        .findFirst()
+        .get();
+    assertEquals(ItemType.CONTENT_ITEM, rule.getItemType().get());
+    assertEquals(IncludeExcludeFilter.Action.INCLUDE, rule.getAction());
+    assertEquals("\\.html$", rule.getPredicate().toString());
+
+    List<IncludeExcludeFilter.Rule> excludeRules =
+        filter.regexExcludeRules.get(ItemType.CONTENT_ITEM);
+    assertEquals(1, excludeRules.size());
+
+    rule = excludeRules.stream()
+        .filter(r -> r.getName().equals("excludeHtml"))
+        .findFirst()
+        .get();
+    assertEquals(ItemType.CONTENT_ITEM, rule.getItemType().get());
+    assertEquals(IncludeExcludeFilter.Action.EXCLUDE, rule.getAction());
+    assertEquals("excluded\\.html$", rule.getPredicate().toString());
+  }
+
+  @Test
+  public void fromConfiguration_prefixRules_rulesCreated() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.includeText.filterType = FILE_PREFIX",
+        "includeExcludeFilter.includeText.filterPattern = /path/to/records",
+        "includeExcludeFilter.includeText.action = INCLUDE",
+
+        "includeExcludeFilter.includeHtml.filterType = FILE_PREFIX",
+        "includeExcludeFilter.includeHtml.filterPattern = /path/to/records/butNotThese",
+        "includeExcludeFilter.includeHtml.action = EXCLUDE"
+      );
+    setupConfig.initConfig(config);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+
+    List<IncludeExcludeFilter.Rule> includeRules = filter.prefixIncludeRules;
+    assertEquals(1, includeRules.size());
+
+    IncludeExcludeFilter.Rule rule = includeRules.get(0);
+    assertEquals(IncludeExcludeFilter.Action.INCLUDE, rule.getAction());
+    assertEquals("/path/to/records", rule.getPredicate().toString());
+
+    List<IncludeExcludeFilter.Rule> excludeRules = filter.prefixExcludeRules;
+    assertEquals(1, excludeRules.size());
+
+    rule = excludeRules.get(0);
+    assertEquals(IncludeExcludeFilter.Action.EXCLUDE, rule.getAction());
+    assertEquals("/path/to/records/butNotThese", rule.getPredicate().toString());
+  }
+
+  @Test
+  public void fromConfiguration_regexIncludeRule_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.rule1.filterType = REGEX",
+        "includeExcludeFilter.rule1.filterPattern = \\\\.txt$",
+        "includeExcludeFilter.rule1.action = INCLUDE");
+    setupConfig.initConfig(config);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
     assertTrue(filter.isAllowed("/path", ItemType.CONTAINER_ITEM));
     assertTrue(filter.isAllowed("/path/to", ItemType.CONTAINER_ITEM));
     assertTrue(filter.isAllowed("/path/to/file.txt", ItemType.CONTENT_ITEM));
@@ -220,161 +586,242 @@ public class IncludeExcludeFilterTest {
   }
 
   @Test
-  public void fromConfiguration_multipleRules_succeeds() {
-    Properties config = new Properties();
-
-    // Include files with given extensions
-    config.setProperty("includeExcludeFilter.includeTextFiles.itemType", "CONTENT_ITEM");
-    config.setProperty("includeExcludeFilter.includeTextFiles.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.includeTextFiles.filterPattern",
-        "\\.(txt|text|htm|html)$");
-    config.setProperty("includeExcludeFilter.includeTextFiles.action", "INCLUDE");
-
-    // Exclude files named XXX-ARCHIVE.YYY
-    config.setProperty("includeExcludeFilter.excludeArchiveFiles.itemType", "CONTENT_ITEM");
-    config.setProperty("includeExcludeFilter.excludeArchiveFiles.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.excludeArchiveFiles.filterPattern",
-        "-ARCHIVE\\.[^/]+$");
-    config.setProperty("includeExcludeFilter.excludeArchiveFiles.action", "EXCLUDE");
-
-    // Exclude folders named XXX-ARCHIVE
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.itemType", "CONTAINER_ITEM");
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.filterPattern",
-        "/[^/]+-ARCHIVE$|/[^/]+-ARCHIVE/"); // assumes path separator is "/"
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.action", "EXCLUDE");
-
-    // Exclude files with a folder named XXX-ARCHIVE in their path. In a listing
-    // connector, the folder would have been excluded by a previous rule, but if the rules
-    // were changed, the file might be polled for re-indexing sooner than the folder; this
-    // rule would allow the connector to delete it.
-    config.setProperty(
-        "includeExcludeFilter.excludeFilesInArchiveFolders.itemType", "CONTENT_ITEM");
-    config.setProperty("includeExcludeFilter.excludeFilesInArchiveFolders.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.excludeFilesInArchiveFolders.filterPattern",
-        "/[^/]+-ARCHIVE/");
-    config.setProperty("includeExcludeFilter.excludeFilesInArchiveFolders.action", "EXCLUDE");
-
+  public void fromConfiguration_regexExcludeRule_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.rule1.filterType = REGEX",
+        "includeExcludeFilter.rule1.filterPattern = \\\\.txt$",
+        "includeExcludeFilter.rule1.action = EXCLUDE");
     setupConfig.initConfig(config);
     IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
-    assertEquals(1, filter.includeRules.get(ItemType.CONTENT_ITEM).size());
-    assertEquals(2, filter.excludeRules.get(ItemType.CONTENT_ITEM).size());
-    assertEquals(1, filter.excludeRules.get(ItemType.CONTAINER_ITEM).size());
 
+    assertTrue(filter.isAllowed("/path", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/path/to", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("filetxt", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("file.txt", ItemType.CONTAINER_ITEM));
+
+    assertTrue(filter.isAllowed("/path/to/file.pdf", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/path/to/file.txt.bak", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("filetxt", ItemType.CONTENT_ITEM));
+
+    assertFalse(filter.isAllowed("/path/to/file.txt", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("file.txt", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("File.TXT", ItemType.CONTENT_ITEM));
+  }
+
+  @Test
+  public void fromConfiguration_filePrefixIncludeRule_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1.filterType = FILE_PREFIX",
+        "includeExcludeFilter.rule1.filterPattern = /folder1/folder2",
+        "includeExcludeFilter.rule1.action = INCLUDE");
+    setupConfig.initConfig(config);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertTrue(filter.isAllowed("/", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2/", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2/file.pdf", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2/file.pdf", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2/folder3/file.pdf", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder2/folder3/file.pdf", ItemType.CONTENT_ITEM));
+
+    assertFalse(filter.isAllowed("/folder3", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder3", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder3", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder3", ItemType.CONTENT_ITEM));
+  }
+
+  @Test
+  public void fromConfiguration_filePrefixExcludeRule_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1.filterType = FILE_PREFIX",
+        "includeExcludeFilter.rule1.filterPattern = /folder1/folder2",
+        "includeExcludeFilter.rule1.action = EXCLUDE");
+    setupConfig.initConfig(config);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+
+    assertTrue(filter.isAllowed("/", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder3", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder3", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder3", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/folder3", ItemType.CONTENT_ITEM));
+
+    assertFalse(filter.isAllowed("/folder1/folder2", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder2", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder2/", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder2/", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder2/file.pdf", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder2/file.pdf", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder2/folder3/file.pdf", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder1/folder2/folder3/file.pdf", ItemType.CONTENT_ITEM));
+  }
+
+  @Test
+  public void fromConfiguration_urlPrefixIncludeRule_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1.filterType = URL_PREFIX",
+        "includeExcludeFilter.rule1.filterPattern = http://example.com/folder1",
+        "includeExcludeFilter.rule1.action = INCLUDE",
+
+        "includeExcludeFilter.rule2.filterType = URL_PREFIX",
+        "includeExcludeFilter.rule2.filterPattern = http://example.com/folder2",
+        "includeExcludeFilter.rule2.action = INCLUDE");
+    setupConfig.initConfig(config);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertTrue(filter.isAllowed("http://example.com", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder1", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder1/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder1/file.txt", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder1/folder3", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder2", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder2/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder2/file.txt", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder2/folder3", ItemType.CONTENT_ITEM));
+
+    assertFalse(filter.isAllowed("http://example.com/folder3", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder3", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder12", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder12", ItemType.CONTENT_ITEM));
+  }
+
+  @Test
+  public void fromConfiguration_urlPrefixExcludeRule_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1.filterType = URL_PREFIX",
+        "includeExcludeFilter.rule1.filterPattern = http://example.com/folder1",
+        "includeExcludeFilter.rule1.action = EXCLUDE",
+
+        "includeExcludeFilter.rule2.filterType = URL_PREFIX",
+        "includeExcludeFilter.rule2.filterPattern = http://example.com/folder2",
+        "includeExcludeFilter.rule2.action = EXCLUDE");
+    setupConfig.initConfig(config);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertTrue(filter.isAllowed("http://example.com", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder3", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder3", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder12", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("http://example.com/folder12", ItemType.CONTENT_ITEM));
+
+    assertFalse(filter.isAllowed("http://example.com/folder1", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder1/", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder1/file.txt", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder1/folder3", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder2", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder2/", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder2/file.txt", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("http://example.com/folder2/folder3", ItemType.CONTENT_ITEM));
+  }
+
+
+
+  @Test
+  public void fromConfiguration_excludeFolders_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1-container.filterType = REGEX",
+        "includeExcludeFilter.rule1-container.itemType = CONTAINER_ITEM",
+        "includeExcludeFilter.rule1-container.filterPattern = /[^/]+-ARCHIVE$|/[^/]+-ARCHIVE/",
+        "includeExcludeFilter.rule1-container.action = EXCLUDE",
+
+        "includeExcludeFilter.rule1-content.filterType = REGEX",
+        "includeExcludeFilter.rule1-content.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.rule1-content.filterPattern = /[^/]+-ARCHIVE/",
+        "includeExcludeFilter.rule1-content.action = EXCLUDE",
+
+        "includeExcludeFilter.rule2.filterType = REGEX",
+        "includeExcludeFilter.rule2.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.rule2.filterPattern = \\\\.(txt|text|htm|html)$",
+        "includeExcludeFilter.rule2.action = INCLUDE");
+    setupConfig.initConfig(config);
+
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
     assertTrue(filter.isAllowed("/path", ItemType.CONTAINER_ITEM));
     assertTrue(filter.isAllowed("/path/current", ItemType.CONTAINER_ITEM));
     assertTrue(filter.isAllowed("/path/current/file.txt", ItemType.CONTENT_ITEM));
     assertTrue(filter.isAllowed("/path/current/file.text", ItemType.CONTENT_ITEM));
     assertTrue(filter.isAllowed("/path/current/file.htm", ItemType.CONTENT_ITEM));
     assertTrue(filter.isAllowed("/path/current/file.html", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/path/last-month-ARCHIVE-notAnArchive/file.txt",
+            ItemType.CONTENT_ITEM));
 
-    assertFalse(filter.isAllowed("/path/current/file-ARCHIVE.html", ItemType.CONTENT_ITEM));
     assertFalse(filter.isAllowed("/path/last-month-ARCHIVE", ItemType.CONTAINER_ITEM));
     assertFalse(filter.isAllowed("/path/last-month-ARCHIVE/", ItemType.CONTAINER_ITEM));
     assertFalse(filter.isAllowed("/path/last-month-ARCHIVE/reports", ItemType.CONTAINER_ITEM));
     assertFalse(filter.isAllowed("/path/last-month-ARCHIVE/file.txt", ItemType.CONTENT_ITEM));
-
-    assertTrue(filter.isAllowed("/path/last-month-ARCHIVE-notAnArchive/file.txt",
-            ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("/path/current/file.pdf", ItemType.CONTENT_ITEM));
   }
 
   @Test
-  public void fromConfiguration_excludeFolder_succeeds() {
-    Properties config = new Properties();
+  public void fromConfiguration_includeFilesFolders_succeeds() throws IOException {
+    Properties config = createProperties(
+        "includeExcludeFilter.rule1.filterType = REGEX",
+        "includeExcludeFilter.rule1.itemType = CONTENT_ITEM",
+        "includeExcludeFilter.rule1.filterPattern = \\\\.(pdf|doc)$",
+        "includeExcludeFilter.rule1.action = INCLUDE",
 
-    // Exclude folders with paths containing folders named /ARCHIVE/.
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.itemType", "CONTAINER_ITEM");
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.filterPattern",
-        "/ARCHIVE$|/ARCHIVE/"); // assumes path separator is "/"
-    config.setProperty("includeExcludeFilter.excludeArchiveFolders.action", "EXCLUDE");
+        "includeExcludeFilter.rule2.filterType = FILE_PREFIX",
+        "includeExcludeFilter.rule2.filterPattern = /folder1",
+        "includeExcludeFilter.rule2.action = INCLUDE",
 
-    // Exclude docs with paths containing folders named /ARCHIVE/.
-    config.setProperty("includeExcludeFilter.excludeDocsInArchiveFolders.itemType", "CONTENT_ITEM");
-    config.setProperty("includeExcludeFilter.excludeDocsInArchiveFolders.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.excludeDocsInArchiveFolders.filterPattern",
-        "/ARCHIVE/"); // assumes path separator is "/"
-    config.setProperty("includeExcludeFilter.excludeDocsInArchiveFolders.action", "EXCLUDE");
-
+        "includeExcludeFilter.rule3.filterType = FILE_PREFIX",
+        "includeExcludeFilter.rule3.filterPattern = /folder2",
+        "includeExcludeFilter.rule3.action = INCLUDE");
     setupConfig.initConfig(config);
+
     IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertTrue(filter.isAllowed("/folder1", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder2", ItemType.CONTAINER_ITEM));
+    assertTrue(filter.isAllowed("/folder1/file.doc", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/file.pdf", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder2/file.doc", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder2/file.pdf", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/path/to/file.doc", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder1/path/to/file.pdf", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder2/path/to/file.doc", ItemType.CONTENT_ITEM));
+    assertTrue(filter.isAllowed("/folder2/path/tofile.pdf", ItemType.CONTENT_ITEM));
 
-    assertTrue(filter.isAllowed("/path", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/path/current", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/path/current/file.txt", ItemType.CONTENT_ITEM));
-    assertTrue(filter.isAllowed("/path/current/file.pdf", ItemType.CONTENT_ITEM));
-    assertTrue(filter.isAllowed("/path/current/file.doc", ItemType.CONTENT_ITEM));
-    assertTrue(filter.isAllowed("/path/current/file.html", ItemType.CONTENT_ITEM));
-
-    assertFalse(filter.isAllowed("/ARCHIVE", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/path/ARCHIVE", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/path/ARCHIVE/", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/path/ARCHIVE/reports", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/path/ARCHIVE/reports/last-month.doc", ItemType.CONTENT_ITEM));
-    assertFalse(filter.isAllowed("/path/is/longer/with/ARCHIVE/folder", ItemType.CONTAINER_ITEM));
-  }
-
-  @Test
-  public void fromConfiguration_includeFolders_succeeds() {
-    Properties config = new Properties();
-
-    // Include only some folders below the root. The parent paths must also be included in
-    // the pattern for a hierarchical repository.
-    config.setProperty("includeExcludeFilter.includePublicFolder.itemType", "CONTAINER_ITEM");
-    config.setProperty("includeExcludeFilter.includePublicFolder.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.includePublicFolder.filterPattern",
-        "^/$|^/root[/]?$|^/root/folder[/]?$|^/root/folder/public[/]?$|^/root/folder/public/");
-    config.setProperty("includeExcludeFilter.includePublicFolder.action", "INCLUDE");
-
-    config.setProperty("includeExcludeFilter.includePressFolder.itemType", "CONTAINER_ITEM");
-    config.setProperty("includeExcludeFilter.includePressFolder.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.includePressFolder.filterPattern",
-        "^/$|^/root[/]?$|^/root/releases[/]?$|^/root/releases/press[/]?$|^/root/releases/press/");
-    config.setProperty("includeExcludeFilter.includePressFolder.action", "INCLUDE");
-
-    // Include .doc files in the public, press folders.
-    config.setProperty("includeExcludeFilter.includeDocsInPublicFolder.itemType", "CONTENT_ITEM");
-    config.setProperty("includeExcludeFilter.includeDocsInPublicFolder.filterType", "REGEX");
-    config.setProperty("includeExcludeFilter.includeDocsInPublicFolder.filterPattern",
-        "^/root/folder/public/.*\\.doc$|^/root/releases/press/.*\\.doc$");
-    config.setProperty("includeExcludeFilter.includeDocsInPublicFolder.action", "INCLUDE");
-
-    setupConfig.initConfig(config);
-    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
-
-    assertTrue(filter.isAllowed("/", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/folder", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/folder/", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/folder/public", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/folder/public/", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/folder/public/path/to/more/content",
-            ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/releases", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/releases/", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/releases/press", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/releases/press/", ItemType.CONTAINER_ITEM));
-    assertTrue(filter.isAllowed("/root/releases/press/path/to/more/content",
-            ItemType.CONTAINER_ITEM));
-
-    assertFalse(filter.isAllowed("/other-folder", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/root/other-folder", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/other-folder/public", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/other-folder/public/path", ItemType.CONTAINER_ITEM));
-    assertFalse(filter.isAllowed("/other-folder/public/path", ItemType.CONTAINER_ITEM));
-
-    assertTrue(filter.isAllowed("/root/folder/public/file.doc", ItemType.CONTENT_ITEM));
-    assertTrue(filter.isAllowed("/root/folder/public/path/to/file.doc", ItemType.CONTENT_ITEM));
-    assertTrue(filter.isAllowed("/root/releases/press/file.doc", ItemType.CONTENT_ITEM));
-    assertTrue(filter.isAllowed("/root/releases/press/path/to/file.doc", ItemType.CONTENT_ITEM));
-
-    assertFalse(filter.isAllowed("/root/folder/public/path/to/file.pdf", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("/folder3", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder12", ItemType.CONTAINER_ITEM));
+    assertFalse(filter.isAllowed("/folder1/file.txt", ItemType.CONTENT_ITEM));
+    assertFalse(filter.isAllowed("/folder2/path/to/file.txt", ItemType.CONTENT_ITEM));
   }
 
   @Test
   public void mainHelper_succeeds() throws Exception {
+    // No rules, one test value.
     IncludeExcludeFilter.mainHelper(new String[0],
         new java.io.ByteArrayInputStream("/path/to/doc.txt".getBytes()));
+  }
+
+  private Properties createProperties(String... propertyLines) throws IOException {
+    String in = String.join(System.getProperty("line.separator"), propertyLines);
+    Properties p = new Properties();
+    p.load(new java.io.StringReader(in));
+    return p;
+  }
+
+  private void createFile(File file, String... content) throws IOException {
+    try (PrintWriter pw = new PrintWriter(new FileWriter(file))) {
+      for (String s : content) {
+        pw.println(s);
+      }
+    }
   }
 }

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilterTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilterTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.enterprise.cloudsearch.sdk.indexing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.enterprise.cloudsearch.sdk.InvalidConfigurationException;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration.ResetConfigRule;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration.SetupConfigRule;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Properties;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IncludeExcludeFilterTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Rule public ResetConfigRule resetConfig = new ResetConfigRule();
+  @Rule public SetupConfigRule setupConfig = SetupConfigRule.uninitialized();
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void fromConfiguration_notInitialized_throwsException() {
+    thrown.expect(IllegalStateException.class);
+    IncludeExcludeFilter.fromConfiguration();
+  }
+
+  @Test
+  public void fromConfiguration_initializedNoConfig_succeeds() {
+    setupConfig.initConfig(new Properties());
+    IncludeExcludeFilter.fromConfiguration();
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertEquals(0, filter.includeRules.size());
+    assertEquals(0, filter.excludeRules.size());
+  }
+
+  @Test
+  public void fromConfiguration_fileMissing_throwsException() {
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile", "/no/such/file");
+    setupConfig.initConfig(config);
+    thrown.expect(InvalidConfigurationException.class);
+    IncludeExcludeFilter.fromConfiguration();
+  }
+
+  @Test
+  public void fromConfiguration_fileIsDirectory_throwsException() throws IOException {
+    File dir = tempFolder.newFolder("testdir");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile", dir.getAbsolutePath());
+    setupConfig.initConfig(config);
+    thrown.expect(InvalidConfigurationException.class);
+    IncludeExcludeFilter.fromConfiguration();
+  }
+
+  @Test
+  public void invalidPatternPrefix_succeeds() throws IOException {
+    File patternsFile = tempFolder.newFile("patterns.txt");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile",
+        patternsFile.getAbsolutePath());
+    setupConfig.initConfig(config);
+    try (FileWriter writer = new FileWriter(patternsFile)) {
+      writer.write("notAPattern");
+    }
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertEquals(0, filter.includeRules.size());
+    assertEquals(0, filter.excludeRules.size());
+  }
+
+  @Test
+  public void invalidRegex_throwsException() throws IOException {
+    File patternsFile = tempFolder.newFile("patterns.txt");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile",
+        patternsFile.getAbsolutePath());
+    setupConfig.initConfig(config);
+    try (FileWriter writer = new FileWriter(patternsFile)) {
+      writer.write("include:regex:*");
+    }
+    thrown.expect(InvalidConfigurationException.class);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+  }
+
+  @Test
+  public void fileNotReadable_throwsException() throws IOException {
+    File patternsFile = tempFolder.newFile("patterns.txt");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile",
+        patternsFile.getAbsolutePath());
+    setupConfig.initConfig(config);
+    try (FileWriter writer = new FileWriter(patternsFile)) {
+      writer.write("include:regex:foo");
+    }
+    patternsFile.setReadable(false);
+    thrown.expect(InvalidConfigurationException.class);
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+  }
+
+  @Test
+  public void validPattern_succeeds() throws IOException {
+    File patternsFile = tempFolder.newFile("patterns.txt");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile",
+        patternsFile.getAbsolutePath());
+    setupConfig.initConfig(config);
+    try (FileWriter writer = new FileWriter(patternsFile)) {
+      writer.write("include:regex:.*\\.txt" + System.lineSeparator());
+      writer.write("include:regex:.*\\.html" + System.lineSeparator());
+      writer.write("exclude:regex:.*\\.pdf" + System.lineSeparator());
+      writer.write("exclude:regex:.*\\.doc" + System.lineSeparator());
+    }
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertEquals(2, filter.includeRules.size());
+    assertEquals(2, filter.excludeRules.size());
+  }
+
+  @Test
+  public void include_succeeds() throws IOException {
+    File patternsFile = tempFolder.newFile("patterns.txt");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile",
+        patternsFile.getAbsolutePath());
+    setupConfig.initConfig(config);
+    try (FileWriter writer = new FileWriter(patternsFile)) {
+      writer.write("include:regex:.*\\.txt$" + System.lineSeparator());
+      writer.write("include:regex:.*\\.html$" + System.lineSeparator());
+    }
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertTrue("/path/to/file.txt", filter.isAllowed("/path/to/file.txt"));
+    assertTrue("/path/to/file.html", filter.isAllowed("/path/to/file.html"));
+    // uses case-insensitive match
+    assertTrue("/path/to/file.HTML", filter.isAllowed("/path/to/file.HTML"));
+    assertFalse("/path/to/file.other", filter.isAllowed("/path/to/file.other"));
+    assertFalse("/path/to/file.txt.bak", filter.isAllowed("/path/to/file.txt.bak"));
+  }
+
+  @Test
+  public void exclude_succeeds() throws IOException {
+    File patternsFile = tempFolder.newFile("patterns.txt");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile",
+        patternsFile.getAbsolutePath());
+    setupConfig.initConfig(config);
+    try (FileWriter writer = new FileWriter(patternsFile)) {
+      writer.write("exclude:regex:.*\\.txt$" + System.lineSeparator());
+      writer.write("exclude:regex:.*\\.html$" + System.lineSeparator());
+    }
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertFalse("/path/to/file.txt", filter.isAllowed("/path/to/file.txt"));
+    assertFalse("/path/to/file.html", filter.isAllowed("/path/to/file.html"));
+    // uses case-insensitive match
+    assertFalse("/path/to/file.HTML", filter.isAllowed("/path/to/file.HTML"));
+    assertTrue("/path/to/file.other", filter.isAllowed("/path/to/file.other"));
+    assertTrue("/path/to/file.txt.bak", filter.isAllowed("/path/to/file.txt.bak"));
+  }
+
+  @Test
+  public void includeExclude_succeeds() throws IOException {
+    File patternsFile = tempFolder.newFile("patterns.txt");
+    Properties config = new Properties();
+    config.put("connector.includeExcludeFilter.includeExcludePatternFile",
+        patternsFile.getAbsolutePath());
+    setupConfig.initConfig(config);
+    try (FileWriter writer = new FileWriter(patternsFile)) {
+      writer.write("include:regex:.*\\.txt$" + System.lineSeparator());
+      writer.write("exclude:regex:.*DEVELOPMENT.*" + System.lineSeparator());
+    }
+    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
+    assertTrue("/path/to/file.txt", filter.isAllowed("/path/to/file.txt"));
+    assertFalse("/path/to/file-DEVELOPMENT.txt",
+        filter.isAllowed("/path/to/file-DEVELOPMENT.txt"));
+  }
+}

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilterTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/IncludeExcludeFilterTest.java
@@ -34,6 +34,9 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/**
+ * Tests for IncludeExcludeFilter.
+ */
 @RunWith(JUnit4.class)
 public class IncludeExcludeFilterTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -76,7 +79,7 @@ public class IncludeExcludeFilterTest {
   }
 
   @Test
-  public void invalidPatternPrefix_succeeds() throws IOException {
+  public void invalidPatternPrefix_throwsException() throws IOException {
     File patternsFile = tempFolder.newFile("patterns.txt");
     Properties config = new Properties();
     config.put("connector.includeExcludeFilter.includeExcludePatternFile",
@@ -85,9 +88,8 @@ public class IncludeExcludeFilterTest {
     try (FileWriter writer = new FileWriter(patternsFile)) {
       writer.write("notAPattern");
     }
-    IncludeExcludeFilter filter = IncludeExcludeFilter.fromConfiguration();
-    assertEquals(0, filter.includeRules.size());
-    assertEquals(0, filter.excludeRules.size());
+    thrown.expect(InvalidConfigurationException.class);
+    IncludeExcludeFilter.fromConfiguration();
   }
 
   @Test


### PR DESCRIPTION
Add a helper class that can be used by connectors to filter items
before indexing.

Bug: 112165186