### PR TITLE
Add getters, toString to ApiOperation classes

### DIFF
--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/DeleteItem.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/DeleteItem.java
@@ -77,6 +77,15 @@ public class DeleteItem implements ApiOperation {
     }
   }
 
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return "DeleteItem [itemId=" + id + "]";
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, Arrays.hashCode(version), requestMode);

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/DeleteQueueItems.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/DeleteQueueItems.java
@@ -58,6 +58,15 @@ public class DeleteQueueItems implements ApiOperation {
     }
   }
 
+  public String getQueueName() {
+      return queueName;
+  }
+
+  @Override
+  public String toString() {
+    return "DeleteQueueItems [queueName=" + queueName + "]";
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(queueName);

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/PushItemResource.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/PushItemResource.java
@@ -22,22 +22,30 @@ import com.google.api.services.cloudsearch.v1.model.PushItem;
 import com.google.common.base.Strings;
 import java.util.Objects;
 
-class PushItemResource {
+/**
+ * Wrapper to pair the item id and PushItem.
+ */
+public class PushItemResource {
   private final String id;
   private final PushItem item;
 
-  PushItemResource(String id, PushItem item) {
+  public PushItemResource(String id, PushItem item) {
     checkArgument(!Strings.isNullOrEmpty(id), "id can not be null or empty");
     this.id = id;
     this.item = checkNotNull(item, "item can not be null");
   }
 
-  String getId() {
+  public String getId() {
     return id;
   }
 
-  PushItem getItem() {
+  public PushItem getItem() {
     return item;
+  }
+
+  @Override
+  public String toString() {
+    return "[itemId=" + id + ", pushItem=" + item + "]";
   }
 
   @Override

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/PushItems.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/PushItems.java
@@ -92,7 +92,7 @@ public class PushItems implements ApiOperation {
 
   @Override
   public String toString() {
-    return "PushItems [items=" + items.toString() + "]";
+    return "PushItems [items=" + items + "]";
   }
 
   @Override

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/PushItems.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/PushItems.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.services.cloudsearch.v1.model.PushItem;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.enterprise.cloudsearch.sdk.indexing.IndexingService;
@@ -83,6 +84,15 @@ public class PushItems implements ApiOperation {
     } catch (ExecutionException e) {
       throw new IOException(e.getCause());
     }
+  }
+
+  public List<PushItemResource> getPushItemResources() {
+    return ImmutableList.copyOf(items);
+  }
+
+  @Override
+  public String toString() {
+    return "PushItems [items=" + items.toString() + "]";
   }
 
   @Override

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/RepositoryDocError.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/template/RepositoryDocError.java
@@ -56,4 +56,20 @@ public class RepositoryDocError implements ApiOperation {
       throw new IOException("Error pushing repository error", e.getCause());
     }
   }
+
+  public String getId() {
+    return itemId;
+  }
+
+  public RepositoryException getException() {
+    return repositoryDocException;
+  }
+
+  @Override
+  public String toString() {
+    return "RepositoryDocError ["
+        + "itemId=" + itemId
+        + ", exception=" + repositoryDocException
+        + "]";
+  }
 }

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/template/ApiOperationsTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/template/ApiOperationsTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.api.services.cloudsearch.v1.model.PushItem;
 import com.google.common.collect.ImmutableList;
+import com.google.enterprise.cloudsearch.sdk.RepositoryException;
 import com.google.enterprise.cloudsearch.sdk.indexing.IndexingService.RequestMode;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -101,5 +102,51 @@ public class ApiOperationsTest {
     if (!(subject instanceof BatchApiOperation)) { // See BatchApiOperation.hashCode()
       assertThat(subject.hashCode(), not(equalTo(other.hashCode())));
     }
+  }
+
+  @Test
+  public void deleteItem_helpers() {
+    DeleteItem deleteItem = (DeleteItem) ApiOperations.deleteItem("itemId");
+    assertThat(deleteItem.getId(), equalTo("itemId"));
+    assertThat(deleteItem.toString(), equalTo("DeleteItem [itemId=itemId]"));
+  }
+
+  @Test
+  public void deleteQueueItems_helpers() {
+    DeleteQueueItems deleteQueueItems =
+        (DeleteQueueItems) ApiOperations.deleteQueueItems("queueName");
+    assertThat(deleteQueueItems.getQueueName(), equalTo("queueName"));
+    assertThat(deleteQueueItems.toString(), equalTo("DeleteQueueItems [queueName=queueName]"));
+  }
+
+  @Test
+  public void pushItems_helpers() {
+    PushItems pushItems = new PushItems.Builder()
+        .addPushItem("item1", new PushItem())
+        .addPushItem("item2", new PushItem().setQueue("test queue"))
+        .addPushItem("item3", new PushItem())
+        .build();
+    assertThat(pushItems.getPushItemResources().size(), equalTo(3));
+    assertThat(pushItems.getPushItemResources().stream()
+        .map(item -> item.getId()).collect(ImmutableList.toImmutableList()),
+        equalTo(ImmutableList.of("item1", "item2", "item3")));
+    assertThat(pushItems.toString(), equalTo("PushItems [items=[[itemId=item1, pushItem={}], "
+            + "[itemId=item2, pushItem={queue=test queue}], [itemId=item3, pushItem={}]]]"));
+    assertThat(pushItems.getPushItemResources().get(0),
+        equalTo(new PushItemResource("item1", new PushItem())));
+  }
+
+  @Test
+  public void repositoryDocError_helpers() {
+    RepositoryDocError error = new RepositoryDocError("itemId",
+        new RepositoryException.Builder()
+        .setErrorMessage("error message")
+        .setErrorType(RepositoryException.ErrorType.UNKNOWN)
+        .setCause(new Exception("test cause"))
+        .build());
+    assertThat(error.getId(), equalTo("itemId"));
+    assertThat(error.toString(), equalTo("RepositoryDocError [itemId=itemId, "
+            + "exception={errorMessage=error message, type=UNKNOWN}, "
+            + "cause=java.lang.Exception: test cause]"));
   }
 }

--- a/sdk/src/main/java/com/google/enterprise/cloudsearch/sdk/RepositoryException.java
+++ b/sdk/src/main/java/com/google/enterprise/cloudsearch/sdk/RepositoryException.java
@@ -59,6 +59,12 @@ public class RepositoryException extends IOException {
     return error;
   }
 
+  @Override
+  public String toString() {
+    return getRepositoryError().toString()
+        + ((getCause() != null) ? ", cause=" + getCause() : "");
+  }
+
   /** Builder for creating {@link RepositoryException} */
   public static class Builder {
     private String message;

--- a/sdk/src/main/java/com/google/enterprise/cloudsearch/sdk/RepositoryException.java
+++ b/sdk/src/main/java/com/google/enterprise/cloudsearch/sdk/RepositoryException.java
@@ -61,7 +61,7 @@ public class RepositoryException extends IOException {
 
   @Override
   public String toString() {
-    return getRepositoryError().toString()
+    return getRepositoryError()
         + ((getCause() != null) ? ", cause=" + getCause() : "");
   }
 

--- a/sdk/src/test/java/com/google/enterprise/cloudsearch/sdk/RepositoryExceptionTest.java
+++ b/sdk/src/test/java/com/google/enterprise/cloudsearch/sdk/RepositoryExceptionTest.java
@@ -35,6 +35,7 @@ public class RepositoryExceptionTest {
     assertNull(error.getErrorMessage());
     assertNull(error.getHttpStatusCode());
     assertNull(error.getType());
+    assertEquals("{}", exception.toString());
   }
 
   @Test
@@ -49,6 +50,8 @@ public class RepositoryExceptionTest {
     // RepositoryError doesn't preserve cause
     assertNull(error.getHttpStatusCode());
     assertNull(error.getType());
+    assertEquals("{errorMessage=error message}, cause=java.lang.Throwable: cause",
+        exception.toString());
   }
 
   @Test
@@ -58,6 +61,7 @@ public class RepositoryExceptionTest {
         .build();
     RepositoryError error = exception.getRepositoryError();
     assertEquals(RepositoryException.ErrorType.UNKNOWN.name(), error.getType());
+    assertEquals("{type=UNKNOWN}", exception.toString());
   }
 
   @Test
@@ -67,5 +71,6 @@ public class RepositoryExceptionTest {
         .build();
     RepositoryError error = exception.getRepositoryError();
     assertEquals(Integer.valueOf(400), error.getHttpStatusCode());
+    assertEquals("{httpStatusCode=400}", exception.toString());
   }
 }


### PR DESCRIPTION
This change is primarily for testing to make it easier to analyze
returned ApiOperations. Adding toString helps with logging.