### PR TITLE
Support external groups

### DIFF
--- a/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsConnector.java
+++ b/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsConnector.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.enterprise.cloudsearch.sdk.identity.externalgroups;
+
+import com.google.enterprise.cloudsearch.sdk.identity.FullSyncIdentityConnector;
+import com.google.enterprise.cloudsearch.sdk.identity.IdentityApplication;
+import java.io.IOException;
+
+/**
+ * Main class for the connector.
+ */
+public class ExternalGroupsConnector {
+  public static void main(String[] args) throws IOException, InterruptedException {
+    IdentityApplication application = new IdentityApplication.Builder(
+        new FullSyncIdentityConnector(new ExternalGroupsRepository()), args).build();
+    application.start();
+  }
+}

--- a/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepository.java
+++ b/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepository.java
@@ -37,6 +37,44 @@ import java.util.logging.Logger;
 
 /**
  * Indexes external groups and their members.
+ * <p>
+ * Example config to run the external groups connector:
+ * <pre>
+ * api.serviceAccountPrivateKeyFile = /path/to/file
+ * api.customerId = ABCDE123
+ * connector.runOnce = true
+ * ## This property must be set to GROUPS to avoid an error trying to sync users
+ * connector.IdentitySyncType = GROUPS
+ * ## This is the identity source in which the groups will be created. This must be a
+ * ## dedicated identity source for this connector.
+ * api.identitySourceId = 1234567890abcde
+ * externalgroups.filename = /path/to/groups.json
+ * </pre>
+ *
+ * <p>
+ * Mapping an external group to the customer principal (all users) is a special case. You
+ * need to create a Google group containing the customer principal and then set that Google
+ * group as the member of the external group to be created here. For example:
+ * <pre>
+ * {
+ *     "externalGroups":[
+ *         {"name":"Everyone",
+ *          "members":[
+ *              {"id":"everyone-group@example.com"}
+ *          ]
+ *         }
+ *     ]
+ * }
+ * </pre>
+ *
+ * <p>
+ * In a content connector, you need to supply two properties to map external group names
+ * present in the source repository ACLs to the groups created in the dedicated identity
+ * source:
+ * <pre>
+ * externalgroups.identitySourceId = 1234567890abcde
+ * externalgroups.filename = /path/to/groups.json
+ * </pre>
  */
 public class ExternalGroupsRepository implements Repository {
   private static final Logger logger = Logger.getLogger(ExternalGroupsRepository.class.getName());

--- a/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepository.java
+++ b/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepository.java
@@ -31,7 +31,6 @@ import com.google.enterprise.cloudsearch.sdk.identity.IdentitySourceConfiguratio
 import com.google.enterprise.cloudsearch.sdk.identity.IdentityUser;
 import com.google.enterprise.cloudsearch.sdk.identity.Repository;
 import com.google.enterprise.cloudsearch.sdk.identity.RepositoryContext;
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.logging.Logger;
@@ -43,8 +42,7 @@ public class ExternalGroupsRepository implements Repository {
   private static final Logger logger = Logger.getLogger(ExternalGroupsRepository.class.getName());
 
   private RepositoryContext repositoryContext;
-  private File groupsFile;
-  private GroupsReader groupsReader;
+  private final GroupsReader groupsReader;
 
   public ExternalGroupsRepository() {
     this(ExternalGroups::fromConfiguration);
@@ -90,10 +88,11 @@ public class ExternalGroupsRepository implements Repository {
       groupsBuilder.add(
           repositoryContext.buildIdentityGroup(group.getName(), membersBuilder::build));
     }
-    return new CheckpointCloseableIterableImpl.Builder<IdentityGroup>(
-        groupsBuilder.build()).build();
+    return new CheckpointCloseableIterableImpl.Builder<IdentityGroup>(groupsBuilder.build())
+        .build();
   }
 
+  @FunctionalInterface
   interface GroupsReader {
     ExternalGroups getGroups() throws IOException;
   }

--- a/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepository.java
+++ b/identity/src/main/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepository.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.enterprise.cloudsearch.sdk.identity.externalgroups;
+
+import com.google.api.services.cloudidentity.v1.model.EntityKey;
+import com.google.api.services.cloudidentity.v1.model.Membership;
+import com.google.api.services.cloudidentity.v1.model.MembershipRole;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.enterprise.cloudsearch.sdk.CheckpointCloseableIterable;
+import com.google.enterprise.cloudsearch.sdk.CheckpointCloseableIterableImpl;
+import com.google.enterprise.cloudsearch.sdk.ExternalGroups;
+import com.google.enterprise.cloudsearch.sdk.InvalidConfigurationException;
+import com.google.enterprise.cloudsearch.sdk.identity.IdentityGroup;
+import com.google.enterprise.cloudsearch.sdk.identity.IdentitySourceConfiguration;
+import com.google.enterprise.cloudsearch.sdk.identity.IdentityUser;
+import com.google.enterprise.cloudsearch.sdk.identity.Repository;
+import com.google.enterprise.cloudsearch.sdk.identity.RepositoryContext;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+/**
+ * Indexes external groups and their members.
+ */
+public class ExternalGroupsRepository implements Repository {
+  private static final Logger logger = Logger.getLogger(ExternalGroupsRepository.class.getName());
+
+  private RepositoryContext repositoryContext;
+  private File groupsFile;
+  private GroupsReader groupsReader;
+
+  public ExternalGroupsRepository() {
+    this(ExternalGroups::fromConfiguration);
+  }
+
+  @VisibleForTesting
+  ExternalGroupsRepository(GroupsReader groupsReader) {
+    this.groupsReader = groupsReader;
+  }
+
+  @Override
+  public void init(RepositoryContext context) throws IOException {
+    repositoryContext = context;
+  }
+
+  // TODO: do we want to support separating display name from group name?
+  @Override
+  public CheckpointCloseableIterable<IdentityGroup> listGroups(byte[] checkpoint)
+      throws IOException {
+    ExternalGroups groups = groupsReader.getGroups();
+    ImmutableList.Builder<IdentityGroup> groupsBuilder = ImmutableList.builder();
+    for (ExternalGroups.ExternalGroup group : groups.getExternalGroups()) {
+      ImmutableSet.Builder<Membership> membersBuilder = ImmutableSet.builder();
+      for (ExternalGroups.MemberKey memberKey : group.getMembers()) {
+        EntityKey entityKey = new EntityKey().setId(memberKey.getId());
+        if (memberKey.getNamespace() != null) {
+          entityKey.setNamespace(memberKey.getNamespace());
+        } else if (memberKey.getReferenceIdentitySourceName() != null) {
+          String sourceName = memberKey.getReferenceIdentitySourceName();
+          IdentitySourceConfiguration config = IdentitySourceConfiguration
+              .getReferenceIdentitySourcesFromConfiguration().get(sourceName);
+          if (config == null) {
+            throw new InvalidConfigurationException(
+                "Missing config for reference identity source " + sourceName);
+          }
+          entityKey.setNamespace(config.getGroupNamespace());
+        } // else id is assumed to be a Google id
+        membersBuilder.add(new Membership()
+            .setPreferredMemberKey(entityKey)
+            .setRoles(Collections.singletonList(new MembershipRole().setName("MEMBER")))
+          );
+      }
+      groupsBuilder.add(
+          repositoryContext.buildIdentityGroup(group.getName(), membersBuilder::build));
+    }
+    return new CheckpointCloseableIterableImpl.Builder<IdentityGroup>(
+        groupsBuilder.build()).build();
+  }
+
+  interface GroupsReader {
+    ExternalGroups getGroups() throws IOException;
+  }
+
+  @Override
+  public CheckpointCloseableIterable<IdentityUser> listUsers(byte[] checkpoint) throws IOException {
+    throw new UnsupportedOperationException("Method not supported.");
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/identity/src/test/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepositoryTest.java
+++ b/identity/src/test/java/com/google/enterprise/cloudsearch/sdk/identity/externalgroups/ExternalGroupsRepositoryTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.enterprise.cloudsearch.sdk.identity.externalgroups;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.cloudidentity.v1.model.EntityKey;
+import com.google.api.services.cloudidentity.v1.model.Membership;
+import com.google.api.services.cloudidentity.v1.model.MembershipRole;
+import com.google.common.collect.ImmutableSet;
+import com.google.enterprise.cloudsearch.sdk.CheckpointCloseableIterable;
+import com.google.enterprise.cloudsearch.sdk.ExternalGroups;
+import com.google.enterprise.cloudsearch.sdk.GroupIdEncoder;
+import com.google.enterprise.cloudsearch.sdk.InvalidConfigurationException;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration.ResetConfigRule;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration.SetupConfigRule;
+import com.google.enterprise.cloudsearch.sdk.identity.IdentityGroup;
+import com.google.enterprise.cloudsearch.sdk.identity.RepositoryContext;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Tests for {@link ExternalGroupsRepository}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExternalGroupsRepositoryTest {
+
+  @Rule public SetupConfigRule setupConfig = SetupConfigRule.uninitialized();
+  @Rule public ResetConfigRule resetConfig = new ResetConfigRule();
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule public TestName testName = new TestName();
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  // The connector requires api.identitySourceId implicitly through the use of
+  // RepositoryContext in the Identity SDK.
+  @Test
+  public void init_missingIdentitySourceId_throwsException() throws IOException {
+    setupConfig.initConfig(new Properties());
+    thrown.expect(InvalidConfigurationException.class);
+    RepositoryContext repositoryContext = RepositoryContext.fromConfiguration();
+  }
+
+  @Test
+  public void listGroups_missingFileConfig_throwsException() throws IOException {
+    Properties config = new Properties();
+    config.put("api.identitySourceId", "test-identitySourceId");
+    setupConfig.initConfig(config);
+    RepositoryContext repositoryContext = RepositoryContext.fromConfiguration();
+    ExternalGroupsRepository groupsRepository = new ExternalGroupsRepository();
+    thrown.expect(InvalidConfigurationException.class);
+    groupsRepository.listGroups(null);
+  }
+
+  @Test
+  public void listGroups_invalidFileConfig_throwsException() throws IOException {
+    Properties config = new Properties();
+    config.put("api.identitySourceId", "test-identitySourceId");
+    config.put("externalgroups.filename", "no-such-file");
+    setupConfig.initConfig(config);
+    RepositoryContext repositoryContext = RepositoryContext.fromConfiguration();
+    ExternalGroupsRepository groupsRepository = new ExternalGroupsRepository();
+    thrown.expect(InvalidConfigurationException.class);
+    groupsRepository.listGroups(null);
+  }
+
+  @Test
+  public void listGroups_emptyIterable() throws Exception {
+    ExternalGroupsRepository groupsRepository =
+        new ExternalGroupsRepository(() -> fromString("{}"));
+    try (CheckpointCloseableIterable<IdentityGroup> iterable = groupsRepository.listGroups(null)) {
+      assertNull(iterable.getCheckpoint());
+      assertFalse(iterable.hasMore());
+      Iterator<IdentityGroup> iterator = iterable.iterator();
+      assertNotNull(iterator);
+      assertFalse(iterator.hasNext());
+    }
+  }
+
+  @Test
+  public void listGroups_oneGroup() throws Exception {
+    String identitySourceId = "test-identitySourceId";
+    final String testGroups =
+        "{\"externalGroups\":["
+        + " {\"name\":\"group-name\","
+        + "  \"members\":[{\"id\":\"member11\"}, {\"id\":\"member22\"}]}"
+        + "]}";
+    IdentityGroup expected = makeIdentityGroup(identitySourceId, "group-name",
+        makeEntityKey("member11"), makeEntityKey("member22"));
+
+    Properties config = new Properties();
+    config.put("api.identitySourceId", identitySourceId);
+    config.put("externalgroups.filename", temporaryFolder.newFile("unused").toString());
+    setupConfig.initConfig(config);
+    RepositoryContext repositoryContext = RepositoryContext.fromConfiguration();
+    ExternalGroupsRepository groupsRepository =
+        new ExternalGroupsRepository(() -> fromString(testGroups));
+    groupsRepository.init(repositoryContext);
+
+    List<IdentityGroup> groups = getAll(groupsRepository.listGroups(null));
+    assertEquals(1, groups.size());
+    IdentityGroup identityGroup = groups.get(0);
+    assertEquals(expected, identityGroup);
+  }
+
+  @Test
+  public void listGroups_windowsGroups() throws Exception {
+    String identitySourceId = "test-identitySourceId";
+    final String testGroups =
+        "{\"externalGroups\":["
+        + " {\"name\":\"Everyone\","
+        + "  \"members\":[ {\"id\":\"customer-principal-group@example.com\"} ]},"
+        + " {\"name\":\"BUILTIN\\\\Administrators\","
+        + "  \"members\":[ {\"id\":\"admin-group\","
+        + "                 \"namespace\":\"identitysources/1234567899\"} ]}"
+        + "]}";
+    List<IdentityGroup> expected = Arrays.asList(
+        makeIdentityGroup(identitySourceId, "Everyone",
+            makeEntityKey("customer-principal-group@example.com")),
+        makeIdentityGroup(identitySourceId, "BUILTIN\\Administrators",
+            makeEntityKey("admin-group", "identitysources/1234567899")));
+    Properties config = new Properties();
+    config.put("api.identitySourceId", identitySourceId);
+    config.put("externalgroups.filename", temporaryFolder.newFile("unused").toString());
+    setupConfig.initConfig(config);
+    RepositoryContext repositoryContext = RepositoryContext.fromConfiguration();
+    ExternalGroupsRepository groupsRepository =
+        new ExternalGroupsRepository(() -> fromString(testGroups));
+    groupsRepository.init(repositoryContext);
+
+    List<IdentityGroup> groups = getAll(groupsRepository.listGroups(null));
+    assertEquals(2, groups.size());
+    assertEquals(expected, groups);
+  }
+
+  @Test
+  public void listGroups_referenceIdentitySource() throws Exception {
+    String identitySourceId = "test-identitySourceId";
+    final String testGroups =
+        "{\"externalGroups\":["
+        + " {\"name\":\"Everyone\","
+        + "  \"members\":[ {\"id\":\"customer-principal-group@example.com\"} ]},"
+        + " {\"name\":\"BUILTIN\\\\Administrators\","
+        + "  \"members\":[ {\"id\":\"admin-group\","
+        + "                 \"referenceIdentitySourceName\":\"idSourceForFileShare\"} ]}"
+        + "]}";
+    List<IdentityGroup> expected = Arrays.asList(
+        makeIdentityGroup(identitySourceId, "Everyone",
+            makeEntityKey("customer-principal-group@example.com")),
+        makeIdentityGroup(identitySourceId, "BUILTIN\\Administrators",
+            makeEntityKey("admin-group", "identitysources/9876543211")));
+
+    Properties config = new Properties();
+    config.put("api.identitySourceId", identitySourceId);
+    config.put("api.referenceIdentitySources", "idSourceForFileShare, idSourceForHogwarts");
+    config.put("api.referenceIdentitySource.idSourceForFileShare.id", "9876543211");
+    config.put("api.referenceIdentitySource.idSourceForHogwarts.id", "77777777");
+    config.put("externalgroups.filename", temporaryFolder.newFile("unused").toString());
+    setupConfig.initConfig(config);
+    RepositoryContext repositoryContext = RepositoryContext.fromConfiguration();
+    ExternalGroupsRepository groupsRepository =
+        new ExternalGroupsRepository(() -> fromString(testGroups));
+    groupsRepository.init(repositoryContext);
+
+    List<IdentityGroup> groups = getAll(groupsRepository.listGroups(null));
+    assertEquals(2, groups.size());
+    assertEquals(expected, groups);
+  }
+
+  @Test
+  public void listGroups_referenceIdentitySource_missingConfig() throws Exception {
+    String identitySourceId = "test-identitySourceId";
+    final String testGroups =
+        "{\"externalGroups\":["
+        + " {\"name\":\"BUILTIN\\\\Administrators\","
+        + "  \"members\":[ {\"id\":\"admin-group\","
+        + "                 \"referenceIdentitySourceName\":\"no-such-source\"} ]}"
+        + "]}";
+
+    Properties config = new Properties();
+    config.put("api.identitySourceId", identitySourceId);
+    config.put("externalgroups.filename", temporaryFolder.newFile("unused").toString());
+    setupConfig.initConfig(config);
+    RepositoryContext repositoryContext = RepositoryContext.fromConfiguration();
+    ExternalGroupsRepository groupsRepository =
+        new ExternalGroupsRepository(() -> fromString(testGroups));
+    groupsRepository.init(repositoryContext);
+
+    thrown.expect(InvalidConfigurationException.class);
+    groupsRepository.listGroups(null);
+  }
+
+  @Test
+  public void listUsers_throwsException() throws Exception {
+    ExternalGroupsRepository groupsRepository = new ExternalGroupsRepository();
+    thrown.expect(UnsupportedOperationException.class);
+    groupsRepository.listUsers(null);
+  }
+
+  @Test
+  public void close_doesNothing() throws Exception {
+    ExternalGroupsRepository groupsRepository = new ExternalGroupsRepository();
+    groupsRepository.close();
+  }
+
+  private EntityKey makeEntityKey(String id) {
+    return makeEntityKey(id, null);
+  }
+
+  private EntityKey makeEntityKey(String id, String namespace) {
+    return new EntityKey()
+        .setId(id)
+        .setNamespace(namespace);
+  }
+
+  private IdentityGroup makeIdentityGroup(String identitySourceId,
+      String groupName, EntityKey... members) {
+    IdentityGroup.Builder builder = new IdentityGroup.Builder()
+        .setGroupIdentity(groupName)
+        .setGroupKey(new EntityKey()
+            .setId(GroupIdEncoder.encodeGroupId(groupName))
+            .setNamespace("identitysources/" + identitySourceId))
+        .setMembers(Arrays.stream(members)
+            .map(member -> new Membership()
+                .setPreferredMemberKey(member)
+                .setRoles(Collections.singletonList(new MembershipRole().setName("MEMBER"))))
+            .collect(ImmutableSet.toImmutableSet()));
+    return builder.build();
+  }
+
+  private String identityGroupToString(IdentityGroup identityGroup) {
+    StringBuilder builder = new StringBuilder()
+        .append("groupIdentity (display name): " + identityGroup.getIdentity()).append("\n")
+        .append("groupKey: " + identityGroup.getGroupKey()).append("\n")
+        .append("members: " + identityGroup.getMembers()).append("\n");
+    return builder.toString();
+  }
+
+  private List<IdentityGroup> getAll(CheckpointCloseableIterable<IdentityGroup> iterable) {
+    List<IdentityGroup> groups = new ArrayList<>();
+    iterable.forEach(groups::add);
+    return groups;
+  }
+
+  private ExternalGroups fromString(String data) throws IOException {
+    return JacksonFactory.getDefaultInstance().fromString(data, ExternalGroups.class);
+  }
+}

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/Acl.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/Acl.java
@@ -39,6 +39,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.junit.rules.TestRule;
@@ -57,6 +59,8 @@ import org.junit.runners.model.Statement;
  * <p>Instances are immutable.
  */
 public class Acl {
+  private static final Logger log = Logger.getLogger(Acl.class.getName());
+
   /** Prefix for identity source ID */
   public static final String IDENTITY_SOURCES_PREFIX = "identitysources";
 
@@ -427,9 +431,10 @@ public class Acl {
     try {
       ExternalGroups groups = ExternalGroups.fromConfiguration();
       return groups.getExternalGroups().stream()
-      .map(group -> group.getName())
-      .collect(ImmutableSet.toImmutableSet());
+          .map(group -> group.getName())
+          .collect(ImmutableSet.toImmutableSet());
     } catch (IOException e) {
+      log.log(Level.INFO, "Not mapping external group names", e);
       return ImmutableSet.of();
     }
   };

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/Acl.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/Acl.java
@@ -17,6 +17,7 @@ package com.google.enterprise.cloudsearch.sdk.indexing;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Suppliers.memoize;
 
 import com.google.api.services.cloudsearch.v1.model.GSuitePrincipal;
 import com.google.api.services.cloudsearch.v1.model.Item;
@@ -25,11 +26,14 @@ import com.google.api.services.cloudsearch.v1.model.Principal;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
+import com.google.enterprise.cloudsearch.sdk.ExternalGroups;
 import com.google.enterprise.cloudsearch.sdk.GroupIdEncoder;
 import com.google.enterprise.cloudsearch.sdk.InvalidConfigurationException;
 import com.google.enterprise.cloudsearch.sdk.config.Configuration;
 import com.google.enterprise.cloudsearch.sdk.indexing.IndexingItemBuilder.ItemType;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,6 +41,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 /**
  * Represents all aspects of access permissions for an uploaded document.
@@ -416,6 +423,36 @@ public class Acl {
         .setUserResourceName(String.format(USER_RESOURCE_NAME_FORMAT, identitySourceId, userId));
   }
 
+  private static Supplier<Set<String>> externalGroupNamesSupplier = () -> {
+    try {
+      ExternalGroups groups = ExternalGroups.fromConfiguration();
+      return groups.getExternalGroups().stream()
+      .map(group -> group.getName())
+      .collect(ImmutableSet.toImmutableSet());
+    } catch (IOException e) {
+      return ImmutableSet.of();
+    }
+  };
+
+  private static Supplier<Set<String>> externalGroupNames = memoize(externalGroupNamesSupplier);
+
+  private static Supplier<String> externalGroupsIdentitySourceIdSupplier = () -> {
+    return Configuration.getString("externalgroups.identitySourceId", "").get();
+  };
+
+  private static Supplier<String> externalGroupsIdentitySourceId =
+      memoize(externalGroupsIdentitySourceIdSupplier);
+
+  /** TestRule to reset the static cached external groups data for tests. */
+  public static class ResetExternalGroupsRule implements TestRule {
+    @Override
+    public Statement apply(Statement base, Description description) {
+      externalGroupsIdentitySourceId = memoize(externalGroupsIdentitySourceIdSupplier);
+      externalGroupsIdentitySourceId = memoize(externalGroupsIdentitySourceIdSupplier);
+      return base;
+    }
+  }
+
   /**
    * Returns an external group principal. This method encodes groupId using {@link
    * GroupIdEncoder#encodeGroupId}
@@ -425,6 +462,11 @@ public class Acl {
    */
   public static Principal getGroupPrincipal(String groupId) {
     checkArgument(!Strings.isNullOrEmpty(groupId), "Group ID can not be empty or null");
+    if (Configuration.isInitialized()
+        && !externalGroupsIdentitySourceId.get().isEmpty()
+        && externalGroupNames.get().contains(groupId)) {
+      return getGroupPrincipal(groupId, externalGroupsIdentitySourceId.get());
+    }
     return new Principal().setGroupResourceName(GroupIdEncoder.encodeGroupId(groupId));
   }
 

--- a/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/Acl.java
+++ b/indexing/src/main/java/com/google/enterprise/cloudsearch/sdk/indexing/Acl.java
@@ -450,6 +450,7 @@ public class Acl {
 
   /** TestRule to reset the static cached external groups data for tests. */
   public static class ResetExternalGroupsRule implements TestRule {
+    // This reset rule may fail to work as desired in a multi-threaded test environment.
     @Override
     public Statement apply(Statement base, Description description) {
       externalGroupNames = memoize(externalGroupNamesSupplier);
@@ -468,6 +469,8 @@ public class Acl {
   public static Principal getGroupPrincipal(String groupId) {
     checkArgument(!Strings.isNullOrEmpty(groupId), "Group ID can not be empty or null");
 
+    // Map external group names to a separate identity source, when configured, rather
+    // than assigning them to the connector's default identity source.
     // TODO(gemerson): the group name comparison here is case-sensitive; is that an issue?
 
     // In a connector, the Configuration class will be almost certainly be initialized,

--- a/sdk/src/main/java/com/google/enterprise/cloudsearch/sdk/ExternalGroups.java
+++ b/sdk/src/main/java/com/google/enterprise/cloudsearch/sdk/ExternalGroups.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.enterprise.cloudsearch.sdk;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.Key;
+import com.google.common.collect.ImmutableList;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Represents external group data. Data is loaded from a JSON file.
+ * <p>
+ * The group names provided here should match the values that might occur in source
+ * repository ACLs when indexing content. For example, if a repository has a group named
+ * "Everyone" used for access control that's not otherwise synced to the Google directory,
+ * then you'd create an entry here for "Everyone". Group names in the JSON file should not
+ * be escaped; the names will be escaped as needed for the Google directory when the
+ * groups are created.
+ * <p>
+ * Use the configuration property <code>externalgroups.filename</code> to specify the file
+ * containing the data.
+ *
+ * <pre>
+ *   {"externalGroups":[
+ *     {"name":"group-name",
+ *      "members":[
+ *        {"id":"member1"},
+ *        {"id":"member2", "namespace":"identitysources/1234567899"}
+ *      ]
+ *     }
+ *    ]
+ *   }
+ * </pre>
+ *
+ * If a member is specified using only an id, that id should correspond to a Google user
+ * or group in the domain. If a member is specified with a namespace, that id should
+ * correspond to an id within the given namespace.
+ */
+public class ExternalGroups extends GenericJson {
+  private static final Logger logger = Logger.getLogger(ExternalGroups.class.getName());
+
+  public static final String CONFIG_EXTERNALGROUPS_FILENAME =
+      "externalgroups.filename";
+
+  public static ExternalGroups fromConfiguration() throws IOException {
+    checkState(Configuration.isInitialized(), "configuration must be initialized");
+    String groupsFilename = Configuration.getString(CONFIG_EXTERNALGROUPS_FILENAME, null).get();
+    logger.log(Level.CONFIG, CONFIG_EXTERNALGROUPS_FILENAME + ": " + groupsFilename);
+    File groupsFile = new File(groupsFilename);
+    if (!(groupsFile.exists() && groupsFile.canRead())) {
+      throw new InvalidConfigurationException(groupsFilename + " can't be read");
+    }
+    return fromFile(groupsFile);
+  }
+
+  public static ExternalGroups fromFile(File groupsFile) throws IOException {
+    // fromReader is documented to close the provided stream.
+    return JacksonFactory.getDefaultInstance().fromReader(
+        new InputStreamReader(new FileInputStream(groupsFile), UTF_8), ExternalGroups.class);
+  }
+
+  @Key
+  public List<ExternalGroup> externalGroups;
+
+  public List<ExternalGroup> getExternalGroups() {
+    if (externalGroups == null) {
+      return ImmutableList.of();
+    }
+    return ImmutableList.copyOf(externalGroups);
+  }
+
+  /**
+   * A single group.
+   */
+  public static class ExternalGroup extends GenericJson {
+    @Key
+    public String name;
+
+    @Key
+    public List<MemberKey> members;
+
+    public String getName() {
+      return name;
+    }
+
+    public List<MemberKey> getMembers() {
+      if (members == null) {
+        return ImmutableList.of();
+      }
+      return ImmutableList.copyOf(members);
+    }
+  }
+
+  /**
+   * The identity information for a member.
+   */
+  public static class MemberKey extends GenericJson {
+    @Key
+    public String id;
+
+    @Key
+    public String namespace;
+
+    @Key
+    public String referenceIdentitySourceName;
+
+    public String getId() {
+      return id;
+    }
+
+    public String getNamespace() {
+      return namespace;
+    }
+
+    public String getReferenceIdentitySourceName() {
+      return referenceIdentitySourceName;
+    }
+  }
+}

--- a/sdk/src/test/java/com/google/enterprise/cloudsearch/sdk/ExternalGroupsTest.java
+++ b/sdk/src/test/java/com/google/enterprise/cloudsearch/sdk/ExternalGroupsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.enterprise.cloudsearch.sdk;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration.ResetConfigRule;
+import com.google.enterprise.cloudsearch.sdk.config.Configuration.SetupConfigRule;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ExternalGroups}. */
+@RunWith(JUnit4.class)
+public class ExternalGroupsTest {
+  private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+  private static final String testGroups =
+        "{\"externalGroups\":["
+        + " {\"name\":\"Everyone\","
+        + "  \"members\":[ {\"id\":\"customer-principal-group@example.com\"} ]},"
+        + " {\"name\":\"BUILTIN\\\\Administrators\","
+        + "  \"members\":[ {\"id\":\"admin-group1\","
+        + "                 \"namespace\":\"identitysources/1234567899\"},"
+        + "                {\"id\":\"admin-group2\","
+        + "                 \"referenceIdentitySourceName\":\"fileserverIdentitySource\"}"
+        + "              ]}"
+        + "]}";
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Rule public ResetConfigRule resetConfig = new ResetConfigRule();
+  @Rule public SetupConfigRule setupConfig = SetupConfigRule.uninitialized();
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void emptyObject_listIsEmpty() throws Exception {
+    ExternalGroups externalGroups = fromString("{}");
+    assertEquals(0, externalGroups.getExternalGroups().size());
+  }
+
+  @Test
+  public void emptyMembers_listIsEmpty() throws Exception {
+    ExternalGroups externalGroups = fromString("{\"externalGroups\":[{\"name\":\"groupName\"}]}");
+    assertEquals(1, externalGroups.getExternalGroups().size());
+    assertEquals(0, externalGroups.getExternalGroups().get(0).getMembers().size());
+  }
+
+  @Test
+  public void multipleGroups_fromString() throws Exception {
+    checkGroups(fromString(testGroups));
+  }
+
+  @Test
+  public void multipleGroups_fromConfiguration() throws Exception {
+    File dataFile = temporaryFolder.newFile("groups.json");
+    createFile(dataFile, testGroups);
+    Properties config = new Properties();
+    config.put("api.identitySourceId", "test-identitySourceId");
+    config.put("externalgroups.filename", dataFile.toString());
+    setupConfig.initConfig(config);
+    checkGroups(ExternalGroups.fromConfiguration());
+  }
+
+  private void checkGroups(ExternalGroups externalGroups) {
+    assertEquals(2, externalGroups.getExternalGroups().size());
+    ExternalGroups.ExternalGroup group = externalGroups.getExternalGroups().get(0);
+    assertEquals("Everyone", group.getName());
+    List<ExternalGroups.MemberKey> members = group.getMembers();
+    assertEquals(1, members.size());
+    assertEquals("customer-principal-group@example.com", members.get(0).getId());
+
+    group = externalGroups.getExternalGroups().get(1);
+    assertEquals("BUILTIN\\Administrators", group.getName());
+    members = group.getMembers();
+    assertEquals(2, members.size());
+    assertEquals("admin-group1", members.get(0).getId());
+    assertEquals("identitysources/1234567899", members.get(0).getNamespace());
+    assertEquals(null, members.get(0).getReferenceIdentitySourceName());
+    assertEquals("admin-group2", members.get(1).getId());
+    assertEquals(null, members.get(1).getNamespace());
+    assertEquals("fileserverIdentitySource", members.get(1).getReferenceIdentitySourceName());
+  }
+
+  @Test
+  public void fromConfiguration_missingFilename_throwsException() throws Exception {
+    Properties config = new Properties();
+    config.put("api.identitySourceId", "test-identitySourceId");
+    setupConfig.initConfig(config);
+    thrown.expect(InvalidConfigurationException.class);
+    ExternalGroups.fromConfiguration();
+  }
+
+  @Test
+  public void fromConfiguration_missingFile_throwsException() throws Exception {
+    Properties config = new Properties();
+    config.put("api.identitySourceId", "test-identitySourceId");
+    config.put("externalgroups.filename", "no-such-file");
+    setupConfig.initConfig(config);
+    thrown.expect(InvalidConfigurationException.class);
+    ExternalGroups.fromConfiguration();
+  }
+
+  @Test
+  public void fromConfiguration_unreadableFile_throwsException() throws Exception {
+    File dataFile = temporaryFolder.newFile("groups.json");
+    dataFile.setReadable(false);
+    Properties config = new Properties();
+    config.put("api.identitySourceId", "test-identitySourceId");
+    config.put("externalgroups.filename", dataFile.toString());
+    setupConfig.initConfig(config);
+    thrown.expect(InvalidConfigurationException.class);
+    ExternalGroups.fromConfiguration();
+  }
+
+  private ExternalGroups fromString(String data) throws Exception {
+    return JSON_FACTORY.fromString(data, ExternalGroups.class);
+  }
+
+  private void createFile(File file, String content) throws IOException {
+    try (PrintWriter pw = new PrintWriter(new FileWriter(file))) {
+      pw.write(content);
+    }
+  }
+}


### PR DESCRIPTION
Add an identity connector to create external groups. Group data is
specified in a JSON file. Groups should be added to an identity source
dedicated to this purpose. This connector is intended to make it
easier to create groups, such as "Everyone" in the Windows
environment, that may appear in ACLs but are not mapped by other
identity connectors.

Add support in Acl.getGroupPrincipal for mapping group names to the
identity source used with the external groups connector. When a
connector is configured with a property pointing to the file used in
the external groups connector, and the identity source id where the
external groups are created, the getGroupPrincipal method will use the
separate identity source id for any groups found in the external
groups file.

Bug: 124328777