### PR TITLE
Update cloudsearch api version and google api client version in order…

### DIFF
--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -122,10 +122,6 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava-jdk5</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.api-client</groupId>
-          <artifactId>google-api-client</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.google.apis/google-api-services-admin-directory -->
@@ -137,10 +133,6 @@
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava-jdk5</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.api-client</groupId>
-          <artifactId>google-api-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/indexing/pom.xml
+++ b/indexing/pom.xml
@@ -134,5 +134,10 @@
       <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>2.2.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/template/ApiOperationsTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/template/ApiOperationsTest.java
@@ -36,9 +36,9 @@ public class ApiOperationsTest {
   private ImmutableList<ApiOperation> parametersForSingleArgumentTests() {
     ImmutableList.Builder<ApiOperation> builder = new ImmutableList.Builder<>();
     builder
-        .add(ApiOperations.deleteItem("foo"))
-        .add(ApiOperations.deleteQueueItems("foo"))
-        .add(new PushItems.Builder().build());
+      .add(ApiOperations.deleteItem("foo"))
+      .add(ApiOperations.deleteQueueItems("foo"))
+      .add(new PushItems.Builder().build());
     builder.add(ApiOperations.batch(builder.build().iterator()));
     return builder.build();
   }
@@ -128,10 +128,9 @@ public class ApiOperationsTest {
         .build();
     assertThat(pushItems.getPushItemResources().size(), equalTo(3));
     assertThat(pushItems.getPushItemResources().stream()
-        .map(item -> item.getId()).collect(ImmutableList.toImmutableList()),
-        equalTo(ImmutableList.of("item1", "item2", "item3")));
-    assertThat(pushItems.toString(), equalTo("PushItems [items=[[itemId=item1, pushItem={}], "
-            + "[itemId=item2, pushItem={queue=test queue}], [itemId=item3, pushItem={}]]]"));
+            .map(item -> item.getId()).collect(ImmutableList.toImmutableList()),
+            equalTo(ImmutableList.of("item1", "item2", "item3")));
+    assertThat(pushItems.toString(), equalTo("PushItems [items=[[itemId=item1, pushItem=GenericData{classInfo=[contentHash, metadataHash, payload, queue, repositoryError, structuredDataHash, type], {}}], [itemId=item2, pushItem=GenericData{classInfo=[contentHash, metadataHash, payload, queue, repositoryError, structuredDataHash, type], {queue=test queue}}], [itemId=item3, pushItem=GenericData{classInfo=[contentHash, metadataHash, payload, queue, repositoryError, structuredDataHash, type], {}}]]]"));
     assertThat(pushItems.getPushItemResources().get(0),
         equalTo(new PushItemResource("item1", new PushItem())));
   }
@@ -140,13 +139,11 @@ public class ApiOperationsTest {
   public void repositoryDocError_helpers() {
     RepositoryDocError error = new RepositoryDocError("itemId",
         new RepositoryException.Builder()
-        .setErrorMessage("error message")
-        .setErrorType(RepositoryException.ErrorType.UNKNOWN)
-        .setCause(new Exception("test cause"))
-        .build());
+            .setErrorMessage("error message")
+            .setErrorType(RepositoryException.ErrorType.UNKNOWN)
+            .setCause(new Exception("test cause"))
+            .build());
     assertThat(error.getId(), equalTo("itemId"));
-    assertThat(error.toString(), equalTo("RepositoryDocError [itemId=itemId, "
-            + "exception={errorMessage=error message, type=UNKNOWN}, "
-            + "cause=java.lang.Exception: test cause]"));
+    assertThat(error.toString(), equalTo("RepositoryDocError [itemId=itemId, exception=GenericData{classInfo=[errorMessage, httpStatusCode, type], {errorMessage=error message, type=UNKNOWN}}, cause=java.lang.Exception: test cause]"));
   }
 }

--- a/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/util/UploaderTest.java
+++ b/indexing/src/test/java/com/google/enterprise/cloudsearch/sdk/indexing/util/UploaderTest.java
@@ -411,7 +411,7 @@ public class UploaderTest {
             schemaFile,
             // append is false. Overwrite file
             false)) {
-      outputStream.write(new Schema().toPrettyString().getBytes(StandardCharsets.UTF_8));
+      outputStream.write("{}".getBytes(StandardCharsets.UTF_8));
       outputStream.flush();
     }
     when(uploaderHelper.createTransport())
@@ -621,7 +621,7 @@ public class UploaderTest {
     uploadRequest.sourceId = "ds1";
     UploadRequest.IndexItemAndContentRequest indexRequest =
         new UploadRequest.IndexItemAndContentRequest();
-    indexRequest.item = new Item().setName("item1").setVersion("1");
+    indexRequest.item = new Item().setName("item1").setVersion("v1");
     indexRequest.isIncremental = true;
     uploadRequest.requests = Collections.singletonList(indexRequest);
     uploader.execute(uploadRequest);

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -153,5 +153,15 @@
       <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-cloudsearch</artifactId>
+      <version>v1-rev20230214-2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.35.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-cloudsearch</artifactId>
-      <version>v1-rev18-1.25.0</version>
+      <version>v1-rev20230214-2.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.25.0</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -175,6 +175,11 @@
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client-jackson2</artifactId>
+      <version>1.28.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/sdk/src/test/java/com/google/enterprise/cloudsearch/sdk/RepositoryExceptionTest.java
+++ b/sdk/src/test/java/com/google/enterprise/cloudsearch/sdk/RepositoryExceptionTest.java
@@ -35,7 +35,7 @@ public class RepositoryExceptionTest {
     assertNull(error.getErrorMessage());
     assertNull(error.getHttpStatusCode());
     assertNull(error.getType());
-    assertEquals("{}", exception.toString());
+    assertEquals("GenericData{classInfo=[errorMessage, httpStatusCode, type], {}}", exception.toString());
   }
 
   @Test
@@ -50,8 +50,7 @@ public class RepositoryExceptionTest {
     // RepositoryError doesn't preserve cause
     assertNull(error.getHttpStatusCode());
     assertNull(error.getType());
-    assertEquals("{errorMessage=error message}, cause=java.lang.Throwable: cause",
-        exception.toString());
+    assertEquals("GenericData{classInfo=[errorMessage, httpStatusCode, type], {errorMessage=error message}}, cause=java.lang.Throwable: cause", exception.toString());
   }
 
   @Test
@@ -61,7 +60,7 @@ public class RepositoryExceptionTest {
         .build();
     RepositoryError error = exception.getRepositoryError();
     assertEquals(RepositoryException.ErrorType.UNKNOWN.name(), error.getType());
-    assertEquals("{type=UNKNOWN}", exception.toString());
+    assertEquals("GenericData{classInfo=[errorMessage, httpStatusCode, type], {type=UNKNOWN}}", exception.toString());
   }
 
   @Test
@@ -71,6 +70,6 @@ public class RepositoryExceptionTest {
         .build();
     RepositoryError error = exception.getRepositoryError();
     assertEquals(Integer.valueOf(400), error.getHttpStatusCode());
-    assertEquals("{httpStatusCode=400}", exception.toString());
+    assertEquals("GenericData{classInfo=[errorMessage, httpStatusCode, type], {httpStatusCode=400}}", exception.toString());
   }
 }


### PR DESCRIPTION
… to support request context boost feature. Fix the following unit tests that began breaking after the version update :

1) ApiOperationsTest
2) RepositoryExceptionTest
3) UploaderTest

`mvn clean install` is working correctly in root directory. All integration tests are running as expected locally.

API Version changes done per package : 
* [google-cloudsearch-indexing-connector-sdk] 
   - google-api-client 1.25.0 -> 2.2.0
* [google-cloudsearch-connector-sdk] 
   - google-api-client 1.25.0 -> 2.2.0
   - google-api-services-cloudsearch v1-rev18-1.25.0 -> v1-rev20230214-2.0.0
* [google-cloudsearch-connector-it-common]
   - google-api-client 1.25.0 -> 1.35.2
 * [google-cloudsearch-indentity-connector-sdk] 
   - Remove exclusion of google-api-client from google-api-services-admin-directory
   - Remove exclusion of google-api-client from google-api-services-cloudidentity